### PR TITLE
fix latlong zero-padding

### DIFF
--- a/wx.go
+++ b/wx.go
@@ -92,7 +92,7 @@ func (w Wx) String() (s string) {
 	// Base prefix
 	latDeg, latMin, latHem := decToDMS(w.Lat, [2]string{"N", "S"})
 	lonDeg, lonMin, lonHem := decToDMS(w.Lon, [2]string{"E", "W"})
-	s = fmt.Sprintf("@%sz%02.0f%02.2f%s/%03.0f%02.2f%s",
+	s = fmt.Sprintf("@%sz%02.0f%05.2f%s/%03.0f%05.2f%s",
 		w.Timestamp.In(time.UTC).Format("021504"),
 		latDeg, latMin, latHem,
 		lonDeg, lonMin, lonHem)


### PR DESCRIPTION
The intent of this PR is to fix a problem with lat/long formatting in wx.go.  The latlong values in the example work fine, but if you feed it eg.. 
Lat:    44.1083775,
Lon:    -107.9386725,
You'll notice it drops a zero in the latitude output: `446.50N/10756.32W`.   This should read: `4406.50N\10756.32W`